### PR TITLE
ci: renovate should not pin peer deps

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -3,7 +3,8 @@
     "config:base",
     "schedule:earlyMondays",
     ":semanticCommitTypeAll(ci)",
-    ":semanticCommitScopeDisabled"
+    ":semanticCommitScopeDisabled",
+    ":pinAllExceptPeerDependencies"
   ],
   "rangeStrategy": "pin",
   "baseBranches": ["dev"],


### PR DESCRIPTION
Please fill in the template below before submitting your pull request. This helps keep a consistent structure for project history.

#### Metadata

- [ ] Feature: a new feature.
- [ ] Bug: a bug fix.
- [ ] Refactor: a code change that neither fixes a bug nor adds a feature.
- [ ] Style: changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.).
- [ ] Test: adding missing tests or correcting existing tests.
- [ ] Performance: a code change that improves performance.
- [ ] Documentation: changes to documentation.
- [ ] Build: changes that affect the build system or external dependencies.
- [x] CI: changes to our CI configuration files and scripts.

#### Changes

I noticed that Renovate was pinning peerDeps and engines in an automated PR. That is not the behavior I want, so adding to the config to turn this off.

#### Checklist

- [x] This PR contains only a **single concern** and is small enough to be reviewed easily.
- [x] Documentation for this issue has been added or updated with this PR.
- [x] Unit tests have been added, if applicable.

#### Screenshots

Please include any relevant screenshots if this PR pertains to a visible UI change.

#### Additional Information

Please include any additional notes you feel are necessary here.
